### PR TITLE
Don't lock json's version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,19 +2,20 @@ PATH
   remote: .
   specs:
     fuelsdk (0.0.5)
-      json (~> 1.7.0)
+      json
       jwt (~> 0.1.6)
       savon (= 2.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    akami (1.2.0)
+    akami (1.2.2)
       gyoku (>= 0.4.0)
-      nokogiri (>= 1.4.0)
+      nokogiri
     builder (3.2.2)
     coderay (1.0.9)
     diff-lcs (1.2.4)
+    ffi (1.9.0)
     ffi (1.9.0-x86-mingw32)
     formatador (0.2.4)
     guard (1.8.2)
@@ -30,8 +31,8 @@ GEM
       builder (>= 2.1.2)
     httpi (2.0.2)
       rack
-    json (1.7.7)
-    jwt (0.1.8)
+    json (1.8.1)
+    jwt (0.1.11)
       multi_json (>= 1.5)
     listen (1.3.0)
       rb-fsevent (>= 0.9.3)
@@ -39,11 +40,17 @@ GEM
       rb-kqueue (>= 0.2)
     lumberjack (1.0.4)
     method_source (0.8.2)
-    mini_portile (0.5.1)
-    multi_json (1.7.9)
-    nokogiri (1.6.0-x86-mingw32)
+    mini_portile (0.5.3)
+    multi_json (1.9.3)
+    nokogiri (1.6.1)
+      mini_portile (~> 0.5.0)
+    nokogiri (1.6.1-x86-mingw32)
       mini_portile (~> 0.5.0)
     nori (2.1.0)
+    pry (0.9.12.2)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.4)
     pry (0.9.12.2-x86-mingw32)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -80,6 +87,7 @@ GEM
     win32console (1.3.2-x86-mingw32)
 
 PLATFORMS
+  ruby
   x86-mingw32
 
 DEPENDENCIES

--- a/fuelsdk.gemspec
+++ b/fuelsdk.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard-rspec"
 
   spec.add_dependency "savon", "2.2.0"
-  spec.add_dependency "json", "~> 1.7.0"
+  spec.add_dependency "json"
   spec.add_dependency "jwt", "~> 0.1.6"
 end


### PR DESCRIPTION
Rails 4 wants to use json `1.8`, so we shouldn't lock this down to `1.7`

@joshuafleck @dawid-sklodowski please review/sign-off
