### PR TITLE
upgrade versioning logic for dependabot

### DIFF
--- a/fuelsdk.gemspec
+++ b/fuelsdk.gemspec
@@ -4,15 +4,9 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fuelsdk/version'
 
 
-gem_version = if ENV['GEM_PRE_RELEASE'].nil? || ENV['GEM_PRE_RELEASE'].empty?
-                FuelSDK::VERSION
-              else
-                "#{FuelSDK::VERSION}.#{ENV['GEM_PRE_RELEASE']}"
-              end
-
 Gem::Specification.new do |spec|
   spec.name          = "fuelsdk"
-  spec.version       = gem_version
+  spec.version       = FuelSDK::VERSION
   spec.authors       = ["MichaelAllenClark", "barberj"]
   spec.email         = []
   spec.description   = %q{Fuel SDK for Ruby}

--- a/lib/fuelsdk/version.rb
+++ b/lib/fuelsdk/version.rb
@@ -1,3 +1,7 @@
 module FuelSDK
-  VERSION = "0.0.8"
+  VERSION = "0.0.8" # rubocop:disable Style/MutableConstant
+
+  # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
+  VERSION << '.' << ENV['GEM_PRE_RELEASE'].strip \
+  unless ENV.fetch('GEM_PRE_RELEASE', '').strip.empty?
 end


### PR DESCRIPTION
upgrade gemstash versioning logic so that dependabot can automatically
manage versions of dependencies in the gemspec

dependabot is used to create automatic PRs for security vulnerabilities