### PR TITLE
upgrade versioning logic for dependabot

### DIFF
--- a/fuelsdk.gemspec
+++ b/fuelsdk.gemspec
@@ -4,15 +4,9 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fuelsdk/version'
 
 
-gem_version = if ENV['GEM_PRE_RELEASE'].nil? || ENV['GEM_PRE_RELEASE'].empty?
-                FuelSDK::VERSION
-              else
-                "#{FuelSDK::VERSION}.#{ENV['GEM_PRE_RELEASE']}"
-              end
-
 Gem::Specification.new do |spec|
   spec.name          = "fuelsdk"
-  spec.version       = gem_version
+  spec.version       = FuelSDK::VERSION
   spec.authors       = ["MichaelAllenClark", "barberj"]
   spec.email         = []
   spec.description   = %q{Fuel SDK for Ruby}

--- a/lib/fuelsdk/version.rb
+++ b/lib/fuelsdk/version.rb
@@ -1,5 +1,5 @@
 module FuelSDK
-  base = "0.0.8"
+  base = "0.0.9"
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"

--- a/lib/fuelsdk/version.rb
+++ b/lib/fuelsdk/version.rb
@@ -1,3 +1,6 @@
 module FuelSDK
-  VERSION = "0.0.8"
+  base = "0.0.8"
+
+  # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
+  VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"
 end


### PR DESCRIPTION
upgrade gemstash versioning logic so that dependabot can automatically
manage versions of dependencies in the gemspec

dependabot is used to create automatic PRs for security vulnerabilities