### PR TITLE
Use auth headers instead of token in request url

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fuelsdk (0.0.11)
+    fuelsdk (0.0.12)
       json (~> 2.3)
       jwt (~> 2.2)
       savon (~> 2.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,19 +65,14 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.3)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.3)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.4)
     savon (2.12.1)
       akami (~> 1.2)
       builder (>= 2.1.2)
@@ -105,7 +100,7 @@ DEPENDENCIES
   guard-rspec
   pry
   rake
-  rspec
+  rspec (~> 2.14)
 
 BUNDLED WITH
    1.17.2

--- a/fuelsdk.gemspec
+++ b/fuelsdk.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "~> 2.14"
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "pry"

--- a/lib/fuelsdk/client.rb
+++ b/lib/fuelsdk/client.rb
@@ -5,7 +5,7 @@ module FuelSDK
 		# You will see in the code some of these
 		# items are being updated via back doors and such.
 		attr_reader :code, :message, :results, :request_id, :body, :raw
-		
+
 		# some defaults
 		def success
 			@success ||= false
@@ -96,7 +96,7 @@ module FuelSDK
 			self.auth_token_expiration = Time.new + response['expiresIn']
 			self.refresh_token = response['refreshToken'] if response.has_key?("refreshToken")
 			return true
-			else 
+			else
 			return false
 			end
 		end
@@ -110,7 +110,7 @@ module FuelSDK
 			s.client = self
 			lists = ids.collect{|id| {'ID' => id}}
 			s.properties = {"EmailAddress" => email, "Lists" => lists}
-			p s.properties 
+			p s.properties
 			s.properties['SubscriberKey'] = subscriber_key if subscriber_key
 
 			# Try to add the subscriber
@@ -130,55 +130,55 @@ module FuelSDK
 		def SendTriggeredSends(arrayOfTriggeredRecords)
 			sendTS = ET_TriggeredSend.new
 			sendTS.authStub = self
-			
+
 			sendTS.properties = arrayOfTriggeredRecords
 			sendResponse = sendTS.send
-			
+
 			return sendResponse
 		end
 		def SendEmailToList(emailID, listID, sendClassficationCustomerKey)
-			email = ET_Email::SendDefinition.new 
-			email.properties = {"Name"=>SecureRandom.uuid, "CustomerKey"=>SecureRandom.uuid, "Description"=>"Created with RubySDK"} 
+			email = ET_Email::SendDefinition.new
+			email.properties = {"Name"=>SecureRandom.uuid, "CustomerKey"=>SecureRandom.uuid, "Description"=>"Created with RubySDK"}
 			email.properties["SendClassification"] = {"CustomerKey"=>sendClassficationCustomerKey}
 			email.properties["SendDefinitionList"] = {"List"=> {"ID"=>listID}, "DataSourceTypeID"=>"List"}
 			email.properties["Email"] = {"ID"=>emailID}
 			email.authStub = self
 			result = email.post
-			if result.status then 
-				sendresult = email.send 
-				if sendresult.status then 
+			if result.status then
+				sendresult = email.send
+				if sendresult.status then
 					deleteresult = email.delete
 					return sendresult
-				else 
+				else
 					raise "Unable to send using send definition due to: #{result.results[0][:status_message]}"
-				end 
+				end
 			else
 				raise "Unable to create send definition due to: #{result.results[0][:status_message]}"
-			end 
-		end 
-			
+			end
+		end
+
 		def SendEmailToDataExtension(emailID, sendableDataExtensionCustomerKey, sendClassficationCustomerKey)
-			email = ET_Email::SendDefinition.new 
-			email.properties = {"Name"=>SecureRandom.uuid, "CustomerKey"=>SecureRandom.uuid, "Description"=>"Created with RubySDK"} 
+			email = ET_Email::SendDefinition.new
+			email.properties = {"Name"=>SecureRandom.uuid, "CustomerKey"=>SecureRandom.uuid, "Description"=>"Created with RubySDK"}
 			email.properties["SendClassification"] = {"CustomerKey"=> sendClassficationCustomerKey}
 			email.properties["SendDefinitionList"] = {"CustomerKey"=> sendableDataExtensionCustomerKey, "DataSourceTypeID"=>"CustomObject"}
 			email.properties["Email"] = {"ID"=>emailID}
 			email.authStub = self
 			result = email.post
-			if result.status then 
-				sendresult = email.send 
-				if sendresult.status then 
+			if result.status then
+				sendresult = email.send
+				if sendresult.status then
 					deleteresult = email.delete
 					return sendresult
-				else 
+				else
 					raise "Unable to send using send definition due to: #{result.results[0][:status_message]}"
-				end 
+				end
 			else
 				raise "Unable to create send definition due to: #{result.results[0][:status_message]}"
-			end 
+			end
 		end
 		def CreateAndStartListImport(listId,fileName)
-			import = ET_Import.new 
+			import = ET_Import.new
 			import.authStub = self
 			import.properties = {"Name"=> "SDK Generated Import #{DateTime.now.to_s}"}
 			import.properties["CustomerKey"] = SecureRandom.uuid
@@ -191,16 +191,16 @@ module FuelSDK
 			import.properties["RetrieveFileTransferLocation"] = {"CustomerKey"=>"ExactTarget Enhanced FTP"}
 			import.properties["UpdateType"] = "AddAndUpdate"
 			result = import.post
-			
-			if result.status then 
-				return import.start 
+
+			if result.status then
+				return import.start
 			else
 				raise "Unable to create import definition due to: #{result.results[0][:status_message]}"
-			end 
-		end 
-			
+			end
+		end
+
 		def CreateAndStartDataExtensionImport(dataExtensionCustomerKey, fileName, overwrite)
-			import = ET_Import.new 
+			import = ET_Import.new
 			import.authStub = self
 			import.properties = {"Name"=> "SDK Generated Import #{DateTime.now.to_s}"}
 			import.properties["CustomerKey"] = SecureRandom.uuid
@@ -213,30 +213,30 @@ module FuelSDK
 			import.properties["RetrieveFileTransferLocation"] = {"CustomerKey"=>"ExactTarget Enhanced FTP"}
 			if overwrite then
 				import.properties["UpdateType"] = "Overwrite"
-			else 
+			else
 				import.properties["UpdateType"] = "AddAndUpdate"
-			end 
+			end
 			result = import.post
-			
-			if result.status then 
-				return import.start 
+
+			if result.status then
+				return import.start
 			else
 				raise "Unable to create import definition due to: #{result.results[0][:status_message]}"
-			end 
-		end 
-			
+			end
+		end
+
 		def CreateProfileAttributes(allAttributes)
-			attrs = ET_ProfileAttribute.new 
+			attrs = ET_ProfileAttribute.new
 			attrs.authStub = self
 			attrs.properties = allAttributes
 			return attrs.post
 		end
-		
+
 		def CreateContentAreas(arrayOfContentAreas)
 			postC = ET_ContentArea.new
 			postC.authStub = self
 			postC.properties = arrayOfContentAreas
-			sendResponse = postC.post			
+			sendResponse = postC.post
 			return sendResponse
 		end
 	end

--- a/lib/fuelsdk/client.rb
+++ b/lib/fuelsdk/client.rb
@@ -47,8 +47,7 @@ module FuelSDK
 
 		def jwt= encoded_jwt
 			raise 'Require app signature to decode JWT' unless self.signature
-			decoded_jwt = JWT.decode(encoded_jwt, self.signature, true)
-			decoded_jwt = decoded_jwt[0] if decoded_jwt.is_a?(Array)
+			decoded_jwt = Array.new.push(JWT.decode(encoded_jwt, self.signature, true)).flatten.first
 
 			self.auth_token = decoded_jwt['request']['user']['oauthToken']
 			self.internal_token = decoded_jwt['request']['user']['internalOauthToken']

--- a/lib/fuelsdk/client.rb
+++ b/lib/fuelsdk/client.rb
@@ -48,6 +48,7 @@ module FuelSDK
 		def jwt= encoded_jwt
 			raise 'Require app signature to decode JWT' unless self.signature
 			decoded_jwt = JWT.decode(encoded_jwt, self.signature, true)
+			decoded_jwt = decoded_jwt[0] if decoded_jwt.is_a?(Array)
 
 			self.auth_token = decoded_jwt['request']['user']['oauthToken']
 			self.internal_token = decoded_jwt['request']['user']['internalOauthToken']

--- a/lib/fuelsdk/http_request.rb
+++ b/lib/fuelsdk/http_request.rb
@@ -72,6 +72,12 @@ module FuelSDK
         _request = method.new uri.request_uri
         _request.body = data.to_json if data
         _request.content_type = options['content_type'] if options['content_type']
+
+        # Add Authorization header if we have an access token
+        if options['access_token']
+          _request.add_field('Authorization', 'Bearer ' + options['access_token'])
+        end
+
         response = http.request(_request)
 
         HTTPResponse.new(response, self, :url => url, :options => options)

--- a/lib/fuelsdk/rest.rb
+++ b/lib/fuelsdk/rest.rb
@@ -69,7 +69,7 @@ module FuelSDK
         begin
           #Try to refresh the token and if we do then we need to regenerate the header as well.
           self.refresh
-          (options['params'] ||= {}).merge! 'access_token' => access_token
+          options.merge! 'access_token' => access_token
           rsp = rest_client.send(action, url, options)
           raise 'Unauthorized' if rsp.message == 'Unauthorized'
         rescue

--- a/lib/fuelsdk/rest.rb
+++ b/lib/fuelsdk/rest.rb
@@ -64,11 +64,11 @@ module FuelSDK
     end
 
     private
-      def rest_request action, url, options={}		
+      def rest_request action, url, options={}
         retried = false
         begin
-          #Try to refresh the token and if we do then we need to regenerate the header as well. 
-          self.refresh 
+          #Try to refresh the token and if we do then we need to regenerate the header as well.
+          self.refresh
           (options['params'] ||= {}).merge! 'access_token' => access_token
           rsp = rest_client.send(action, url, options)
           raise 'Unauthorized' if rsp.message == 'Unauthorized'

--- a/lib/fuelsdk/targeting.rb
+++ b/lib/fuelsdk/targeting.rb
@@ -13,7 +13,7 @@ module FuelSDK::Targeting
 
   protected
     def determine_stack
-      options = {'params' => {'access_token' => self.access_token}}
+      options = { 'access_token' => self.access_token }
       response = get("https://www.exacttargetapis.com/platform/v1/endpoints/soap", options)
       @endpoint = response['url']
     rescue => e

--- a/lib/fuelsdk/version.rb
+++ b/lib/fuelsdk/version.rb
@@ -1,5 +1,5 @@
 module FuelSDK
-  base = "0.0.11"
+  base = "0.0.12"
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"

--- a/lib/new.rb
+++ b/lib/new.rb
@@ -85,6 +85,12 @@ module FuelSDK
 
       end
     end
+
+    private
+
+    def add_authorization_header(request, authStub)
+      request.add_field('Authorization', 'Bearer ' + authStub.authToken)
+    end
   end
 
   class ET_CreateWSDL
@@ -282,12 +288,13 @@ module FuelSDK
     protected
       def determineStack()
         begin
-          uri = URI.parse("https://www.exacttargetapis.com/platform/v1/endpoints/soap?access_token=" + @authToken)
+          uri = URI.parse('https://www.exacttargetapis.com/platform/v1/endpoints/soap')
           http = Net::HTTP.new(uri.host, uri.port)
 
           http.use_ssl = true
 
           request = Net::HTTP::Get.new(uri.request_uri)
+          request.add_field('Authorization', 'Bearer ' + @authToken)
 
           contextResponse = JSON.parse(http.request(request).body)
           @endpoint = contextResponse['url']
@@ -767,20 +774,16 @@ module FuelSDK
 
 
   class ET_GetRest < ET_Constructor
-    def initialize(authStub, endpoint, qs = nil)
+    def initialize(authStub, endpoint, qs = {})
       authStub.refreshToken
-
-      if qs then
-        qs['access_token'] = authStub.authToken
-      else
-        qs = {"access_token" => authStub.authToken}
-      end
 
       uri = URI.parse(endpoint)
       uri.query = URI.encode_www_form(qs)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       request = Net::HTTP::Get.new(uri.request_uri)
+      add_authorization_header(request, authStub)
+
       requestResponse = http.request(request)
 
       @moreResults = false
@@ -795,17 +798,13 @@ module FuelSDK
     def initialize(authStub, endpoint, qs = nil)
       authStub.refreshToken
 
-      if qs then
-        qs['access_token'] = authStub.authToken
-      else
-        qs = {"access_token" => authStub.authToken}
-      end
-
       uri = URI.parse(endpoint)
       uri.query = URI.encode_www_form(qs)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       request = Net::HTTP::Get.new(uri.request_uri)
+      add_authorization_header(request, authStub)
+
       requestResponse = http.request(request)
 
       @moreResults = false
@@ -819,18 +818,17 @@ module FuelSDK
     def initialize(authStub, endpoint, payload)
       authStub.refreshToken
 
-      qs = {"access_token" => authStub.authToken}
       uri = URI.parse(endpoint)
-      uri.query = URI.encode_www_form(qs)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       request = Net::HTTP::Post.new(uri.request_uri)
       request.body =  payload.to_json
       request.add_field "Content-Type", "application/json"
+      add_authorization_header(request, authStub)
+
       requestResponse = http.request(request)
 
       super(requestResponse, true)
-
     end
   end
 
@@ -838,17 +836,17 @@ module FuelSDK
     def initialize(authStub, endpoint, payload)
       authStub.refreshToken
 
-      qs = {"access_token" => authStub.authToken}
       uri = URI.parse(endpoint)
-      uri.query = URI.encode_www_form(qs)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       request = Net::HTTP::Patch.new(uri.request_uri)
       request.body =  payload.to_json
       request.add_field "Content-Type", "application/json"
-      requestResponse = http.request(request)
-      super(requestResponse, true)
+      add_authorization_header(request, authStub)
 
+      requestResponse = http.request(request)
+
+      super(requestResponse, true)
     end
   end
 
@@ -856,13 +854,12 @@ module FuelSDK
     def initialize(authStub, endpoint)
       authStub.refreshToken
 
-      qs = {"access_token" => authStub.authToken}
-
       uri = URI.parse(endpoint)
-      uri.query = URI.encode_www_form(qs)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       request = Net::HTTP::Delete.new(uri.request_uri)
+      add_authorization_header(request, authStub)
+
       requestResponse = http.request(request)
       super(requestResponse, true)
 

--- a/spec/targeting_spec.rb
+++ b/spec/targeting_spec.rb
@@ -19,7 +19,7 @@ describe FuelSDK::Targeting do
     let(:client) { c = Class.new.new.extend(FuelSDK::Targeting)
       c.stub(:access_token).and_return('open_sesame')
       c.stub(:get)
-        .with('https://www.exacttargetapis.com/platform/v1/endpoints/soap',{'params'=>{'access_token'=>'open_sesame'}})
+        .with('https://www.exacttargetapis.com/platform/v1/endpoints/soap',{'access_token'=> 'open_sesame'})
         .and_return({'url' => 'S#.authentication.target'})
       c
     }


### PR DESCRIPTION
https://trello.com/c/FLmRpK6r/1535-2-change-how-we-are-sending-accesstoken-in-et

Changes:

* Uses `Authorization` header instead of `access_token` passed through `query_string` params
* Restores tests back to be green

Tested in the scope of https://github.com/simplybusiness/Skynet tests